### PR TITLE
fix(ci): give permission to release drafter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,11 @@ on:
       - master
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
-        with:
-          config-name: release-drafter.yml
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the `release.yml` workflow to grant `contents: write` and `pull-requests: write` permissions to the Release Drafter.  
By moving to `release-drafter@v6` and specifying the correct permissions, we can address the “Resource not accessible by integration” error when creating new releases.

**Changes**:
- Set `contents: write` and `pull-requests: write` in `permissions` for `release-drafter`.
- Updated action from `release-drafter@v5` to `release-drafter@v6`.

**Why**:
- Release Drafter needs `write` permissions to create or update draft releases and manage pull requests successfully.
- Previously, it failed to create draft releases (403 error).
