### PR TITLE
chore(ci): update stale issue and PR handling with new messaging and timing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
     - cron: "30 1 * * *"
 
 jobs:
-  close-issues:
+  handle-stale-issue-and-pr:
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,15 +1,31 @@
-name: Close stale issues and PRs
+name: Close inactive issues and PRs
+
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 jobs:
-  stale:
+  close-issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
         with:
-          stale-issue-message: '👋 Just a heads-up! This issue has been quiet for 30 days. To keep things tidy, we'll automatically close it in 5 days unless there’s new activity. You can add a comment or remove the `stale` label to keep it open. Thanks for helping us keep slackle clean and focused! ✨'
-          stale-pr-message: '🚀 This pull request has been inactive for 30 days. If there’s no further update, it will be closed in 5 days to keep things tidy. You can comment or remove the `stale` label to keep it alive. Thanks for contributing to slackle! 🙏'
-          days-before-stale: 30
-          days-before-close: 5
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+
+          stale-issue-message: "👋 Just a heads-up! This issue has been quiet for 30 days. To keep things tidy, we'll automatically close it in 14 days unless there’s new activity. You can add a comment or remove the `stale` label to keep it open. Thanks for helping us keep slackle clean and focused! ✨"
+          close-issue-message: "❌ This issue was closed because it has been inactive for 14 days since being marked as stale. Feel free to reopen if it's still relevant!"
+
+          stale-pr-message: "🚀 This pull request has been inactive for 30 days. If there’s no further update, it will be closed in 14 days to keep things tidy. You can comment or remove the `stale` label to keep it alive. Thanks for contributing to slackle! 🙏"
+          close-pr-message: "❌ This pull request was closed due to 14 days of inactivity after being marked as stale. Feel free to reopen if you're still working on this!"
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What's changed
* Replaced `days-before-stale` / `days-before-close` with more granular controls:
  - `days-before-issue-stale`: 30 days
  - `days-before-issue-close`: 14 days
  - `days-before-pr-stale`: 30 days
  - `days-before-pr-close`: 14 days
* Explicitly added labels for stale items: `"stale"`
* Updated stale and close messages with a more friendly tone, customized for Slackle:
  - Encourages activity while maintaining a clean repository
* Added `permissions:` block to allow the action to modify issues and PRs

### Purpose
This PR resolves a previous YAML syntax issue and improves the stale bot workflow with more configurable parameters and customized messaging, tailored for the Slackle project.
<img width="393" alt="capture" src="https://github.com/user-attachments/assets/2c41948e-3892-4d74-8b8a-bf99331d4e29" />