### PR TITLE
fix(ci): fix full changelog template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -47,4 +47,4 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: [$PREVIOUS_TAG...v$RESOLVED_VERSION]($REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)
+  **Full Changelog**: [$PREVIOUS_TAG...v$RESOLVED_VERSION](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION)


### PR DESCRIPTION
### What’s changed:
* Fixed Full Changelog link in release notes
* Replaced relative link path (/$REPOSITORY/...) with absolute URL using $OWNER and $REPOSITORY
* Prevents GitHub from misinterpreting the path as a blob link
* Ensures correct redirection to compare view (e.g. v0.2.1...v0.2.2)

### Purpose:

To ensure users can properly navigate to the changelog comparison between releases directly from the release notes.