### PR TITLE
docs(readme): change default logo for PyPI light background

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://slackle.dev/static/logo-light.png">
       <source media="(prefers-color-scheme: light)" srcset="https://slackle.dev/static/logo-dark.png">
-      <img alt="Slackle" src="https://slackle.dev/static/logo-light.png" width="500">
+      <img alt="Slackle" src="https://slackle.dev/static/logo-dark.png" width="500">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
### What's changed:
- Changed the default logo in `README.md` from the light version to the dark version.

### Purpose:
- The light version of the image doesn't render well against PyPI's light background.
- This PR ensures that the logo displays properly in environments that do not support dark mode, which typically have a light background.