### PR TITLE
chore(pytest): add source path to pytest pythonpath in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]
+
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.2.4"


### PR DESCRIPTION
### What's Changed
- Add source path to `pytest` config in `pyproject.toml`

### Purpose
- Prevents `ModuleNotFoundError` when running `pytest`
- Ensures tests can correctly resolve `slackle` modules from the `src/` directory